### PR TITLE
fix/sops installation

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -19,7 +19,7 @@ RUN apt-get update && \
         gpg && \
     apt-get clean && \
     rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/* && \
-    curl -o /usr/local/bin/sops -L https://github.com/getsops/sops/releases/download/${SOPS_VERSION}/sops-${SOPS_VERSION}.linux && \
+    curl -o /usr/local/bin/sops -L https://github.com/getsops/sops/releases/download/${SOPS_VERSION}/sops-${SOPS_VERSION}.linux.amd64 && \
     chmod +x /usr/local/bin/sops &&\
     cd /usr/local/bin && \
     mv helm helm.bin && \


### PR DESCRIPTION
- fix: change argocd to be numeric user (#3)
- feat/enable helm gcs (#4)
- refactor/update argo image (#5)
- feat: Bump argocd and helm secrets version (#6)
- chore/upgrade argocd (#7)
- fix/ksops (#8)
- fix(kustomize): add config env var
- chore(argocd): bump version
- fix(ksops): install inside config plugins
- style: add descriptive coments for tools
- fix(helm-secrets): add back helm secrets wrapper
- fix(helm-secrets): change installation method
- fix(helm-secrets): add helm plugins env var
- fix(sops): enable binary in path
- feat: upgrade argocd to 2.8.5 latest (#9)
- chore/upgrade argocd 2.9.3 (#10)
- fix(argocd): sops link installation
